### PR TITLE
Fixed X stepper skipping steps when cutting filament

### DIFF
--- a/bambu_lab_a1_mini_change_filament_no_ams.gcode
+++ b/bambu_lab_a1_mini_change_filament_no_ams.gcode
@@ -4,7 +4,7 @@
 ;===== Based on work of eukatree and some contributors (Hillbilly-Phil and pakonambawan)
 ;===== https://github.com/eukatree/Bambu_CustomGCode/
 ;=====
-;===== Updated: 20240907
+;===== Updated: 20250127
 ;================================================
 ;
 ;===== Install instructions (Bambu Studio / Orca Slicer):
@@ -22,7 +22,7 @@
 ; flushing volumes can be set in Bambu Studio as if using an AMS)
 ;
 ;===== machine: A1 mini =========================
-;===== date: 20240830 =======================
+;===== date: 20250127 =======================
 G392 S0
 M1007 S0
 ;M620 S[next_extruder]A ; REMOVED: skips all next code if no AMS is available
@@ -40,9 +40,14 @@ M106 P2 S0
 M104 S[old_filament_temp]
 {endif}
 
-G1 X180 F18000
-G1 X197 F500 ; ADDED: finetuning by pakonambawan
-G1 X180 F500 ; ADDED: finetuning by pakonambawan
+G1 X185 F18000 ; moves next to cutting position
+M17 S ; saves the default stepper current values
+M400 ; waits for commands to complete
+M17 X1 ; sets x stepper current higher
+G1 X197 F400 ; cuts filament a little slower, ADDED: finetuning by pakonambawan
+G1 X185 F500 ; returns back to position before cutting, ADDED: finetuning by pakonambawan
+M400 ; waits for commands to complete
+M17 R ; restores saved stepper current values
 
 M620.1 E F[old_filament_e_feedrate] T{nozzle_temperature_range_high[previous_extruder]}
 M620.10 A0 F[old_filament_e_feedrate]
@@ -254,5 +259,3 @@ M623
 
 G392 S0
 M1007 S1
-
-


### PR DESCRIPTION
This PR fixes #1 

I had issues with the X stepper of my A1 mini skipping steps during the cutting part of your code, so I decided to do an investigation. I thought that this must have to do with stepper current. In the default start gcode, M17 is used
```
...
M17 Z0.3 ; lower the z-motor current

G90
M17 X0.7 Y0.9 Z0.5 ; reset motor current to default
...
```
And in the default end gcode:

```
...
M400 ; wait all motion done
M17 S
M17 Z0.4 ; lower z motor current to reduce impact if there is something in the bottom
{if (max_layer_z + 100.0) < 180}
    G1 Z{max_layer_z + 100.0} F600
    G1 Z{max_layer_z +98.0}
{else}
    G1 Z180 F600
    G1 Z180
{endif}
M400 P100
M17 R ; restore z current
...
```
I assumed, that:
`M17 X Y Z` sets stepper current
`M17 S` saves currently used values of current
`M17 R` restores saved values of current

I confirmed my assumptions by writing this simple testing g-code file:

```
M109 S200 ; heat nozzle to simulate print
G28 T300 ; home, ignoring heated nozzle
M83 ; extruder relative
M17 X0.7 Y0.9 Z0.5 ; sets default stepper current, this can be found in default start gcode
G1 Z15 F1000 ; lifts
G1 X185 F18000 ; moves next to cutting position
M17 S ; saves the default stepper current values
M400 ; waits for commands to complete
M17 X1 ; sets x stepper current higher
G1 X197 F400 ; cuts filament a little slower
G1 X185 F500 ; returns back to position before cutting, high current still applied, because force from arm is still being applied
M400 ; waits for commands to complete
M17 R ; restores saved stepper current values
G1 X180 F18000 ; moves little to the left, so that cutter doesnt apply pressure to filament when extruding
G1 E10 F180 ; extrudes a little to get new, uncut filament to cut
G1 X185 F18000 ; moves next to cutting position
G1 X197 F400 ; cuts filament a little slower
G1 X185 F500 ; returns back to position before cutting, high current still applied, because force from arm is still being applied
```
...and running it, as viewed in the attached video (playing with sound recommended):

https://github.com/user-attachments/assets/1aeb4e65-b0c6-49a1-90fc-1dfb833f701a

The first cut is executed at higher stepper current value, the second one uses default values.
I then applied these findings to your g-code, adjusting here:

```
...
G1 X185 F18000 ; moves next to cutting position
M17 S ; saves the default stepper current values
M400 ; waits for commands to complete
M17 X1 ; sets x stepper current higher
G1 X197 F400 ; cuts filament a little slower, ADDED: finetuning by pakonambawan
G1 X185 F500 ; returns back to position before cutting, ADDED: finetuning by pakonambawan
M400 ; waits for commands to complete
M17 R ; restores saved stepper current values
...
```

...and tried to print in two colors. As you can see in the following video, the fix worked for me.

https://github.com/user-attachments/assets/c8961161-3cdb-482e-bb52-6b8c427fc7a4

As of now, the used value of current for cutting is X1 ( one Ampere?) based on my testing:

![IMG_20250128_192650818](https://github.com/user-attachments/assets/d62fd01e-b25b-45eb-9d9f-dabb61bf5424)
![IMG_20250128_192657626](https://github.com/user-attachments/assets/ffce0043-9be9-4cf9-b1b8-c743dac89938)


If this value is too low for you, you can suggest here.